### PR TITLE
Bump GHA to v4

### DIFF
--- a/.github/workflows/algolia-search-scraper.yaml
+++ b/.github/workflows/algolia-search-scraper.yaml
@@ -26,7 +26,7 @@ jobs:
             "orion",
           ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: config
         name: Read ${{ matrix.version }}.json
         shell: bash
@@ -34,7 +34,7 @@ jobs:
           content=$(cat ./.github/config/${{ matrix.version }}.json | jq -r tostring)
           echo "configJSON=$content" >> $GITHUB_OUTPUT
       - name: Checkout algolia/docsearch-scraper
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: algolia/docsearch-scraper
           path: "./algolia"

--- a/build/action.yml
+++ b/build/action.yml
@@ -23,7 +23,7 @@ runs:
       id: nvm
       
     - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         registry-url: https://registry.npmjs.org/
         node-version-file: '.nvmrc'

--- a/build/action.yml
+++ b/build/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha-2023

--- a/case/action.yml
+++ b/case/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha-2023

--- a/linkcheck/action.yml
+++ b/linkcheck/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -23,7 +23,7 @@ runs:
       id: nvm
       
     - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         registry-url: https://registry.npmjs.org/
         node-version-file: '.nvmrc'

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha-2023

--- a/pages-deploy/action.yml
+++ b/pages-deploy/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha-2023

--- a/pages-deploy/action.yml
+++ b/pages-deploy/action.yml
@@ -23,7 +23,7 @@ runs:
       id: nvm
       
     - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
         registry-url: https://registry.npmjs.org/      

--- a/pages-pr-deploy/action.yml
+++ b/pages-pr-deploy/action.yml
@@ -35,7 +35,7 @@ runs:
       id: nvm
       
     - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
         registry-url: https://registry.npmjs.org/      

--- a/pages-pr-deploy/action.yml
+++ b/pages-pr-deploy/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha-2023

--- a/release/action.yml
+++ b/release/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha-2023

--- a/release/action.yml
+++ b/release/action.yml
@@ -27,7 +27,7 @@ runs:
       id: nvm
 
     - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         registry-url: https://registry.npmjs.org/
         node-version-file: '.nvmrc'

--- a/spelling/action.yml
+++ b/spelling/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Consensys/docs-gha-2023
         path: .docs-gha-2023


### PR DESCRIPTION
I had some linting checks fail on me over the last few days (false positives), and I _think_ it might be because we haven't upgraded the GHA scripts to v4.

But, I mean, even if it was an error on my part, we should bump them. 

Thank you!