### PR TITLE
update to remove unused inputs

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -3,11 +3,6 @@
 name: 'build'
 description: 'Composite action to build the docs'
 
-inputs:
-  GITHUB_TOKEN:
-    description: 'Github secret Token'
-    required: true
-
 runs:
   using: "composite"
   steps:

--- a/case/action.yml
+++ b/case/action.yml
@@ -8,9 +8,6 @@ inputs:
     description: "default directory path from project root"
     required: false
     default: docs
-  GITHUB_TOKEN:
-    description: "token to run with correct permissions"
-    required: true
   SKIP_TEST:
     description: "set to true to skip case test"
     required: false
@@ -44,7 +41,3 @@ runs:
           echo "Wrong example: My-Folder/MyFile-NAME.old.md"
           exit 1
         fi
-      env:
-        # Required, set by GitHub actions automatically:
-        # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -2,11 +2,6 @@
 ---
 name: 'Dependency Review'
 
-inputs:
-  GITHUB_TOKEN:
-    description: 'Github secret Token'
-    required: true
-
 runs:
   using: "composite"
   steps:

--- a/lint-markdown/action.yml
+++ b/lint-markdown/action.yml
@@ -4,9 +4,6 @@ name: 'lint: markdown'
 description: 'Composite action to lint markdown'
 
 inputs:
-  GITHUB_TOKEN:
-    description: 'Github secret Token'
-    required: true
   CONFIG_FILE:
     description: 'markdownlint config file'
     required: false

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -3,11 +3,6 @@
 name: 'test: lint all code'
 description: 'Composite action to lint all kind of files'
 
-inputs:
-  GITHUB_TOKEN:
-    description: 'Github secret Token'
-    required: true
-
 runs:
   using: "composite"
   steps:

--- a/mm-security-scanner/action.yml
+++ b/mm-security-scanner/action.yml
@@ -4,9 +4,6 @@ name: 'MetaMask Security Code Scanner'
 description: 'MetaMask Security Code Scanner'
 
 inputs:
-  GITHUB_TOKEN:
-    description: 'Github secret Token'
-    required: true
   SECURITY_SCAN_METRICS_TOKEN:
     description: 'Metrics token'
     required: true

--- a/spelling/action.yml
+++ b/spelling/action.yml
@@ -4,9 +4,6 @@ name: 'test: spelling'
 description: 'Composite action to test spelling'
 
 inputs:
-  GITHUB_TOKEN:
-    description: 'Github secret Token'
-    required: true
   FILEPATHS:
     description: 'Filepaths to look at, specified as a comma separated string ie "docs,blog,etc"'
     required: false
@@ -29,9 +26,6 @@ runs:
         vale_flags: "--config .docs-gha/spelling/.vale.ini --glob={*.md,*.mdx}"
         # fail_on_error: true
         reporter: github-pr-check
-      env:
-        # Required, set by GitHub actions automatically:
-        # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
 
      

--- a/trivy/action.yml
+++ b/trivy/action.yml
@@ -3,11 +3,6 @@
 name: 'Trivy'
 description: 'Composite action to run trivy on the npm package.json'
 
-inputs:
-  GITHUB_TOKEN:
-    description: 'Github secret Token'
-    required: true
-
 runs:
   using: "composite"
   steps:
@@ -30,4 +25,5 @@ runs:
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: 'trivy-results.sarif'        
+        sarif_file: 'trivy-results.sarif'
+  


### PR DESCRIPTION
If we aren;t doing anything to GitHub repo or content you don't need the token so removing the vars - the actions will use the default token from the run