### PR TITLE
Consider 400 to be alive

### DIFF
--- a/linkcheck/config/link-check.json
+++ b/linkcheck/config/link-check.json
@@ -76,6 +76,6 @@
     }
   ],
   "timeout": "30s",
-  "aliveStatusCodes":[200, 206, 403],
+  "aliveStatusCodes":[200, 206, 400, 403],
   "retryOn429":true
 }


### PR DESCRIPTION
400 errors are generally false positives caused by the link checker being unable to resolve internal links (although Docusaurus can).
Docusaurus will detect broken internal links during the build process, so these can probably be considered alive.