### PR TITLE
Add Android links to ignore

### DIFF
--- a/linkcheck/config/link-check.json
+++ b/linkcheck/config/link-check.json
@@ -66,8 +66,8 @@
       "pattern": "^https?://www\\.hackquest\\.io/en/hackathon/Linea-Dev-Cook-Off"
     },
     {
-      "comment": "Ignore specific Android links",
-      "pattern": "^https?://developer\\.android\\.com/guide/components/(processes-and-threads#IPC|aidl)"
+      "comment": "Ignore specific Android developer links",
+      "pattern": "^https?://developer\\.android\\.com/(training/dependency-injection/hilt-android|guide/components/(processes-and-threads#IPC|aidl))"
     }
   ],
   "httpHeaders": [

--- a/linkcheck/config/link-check.json
+++ b/linkcheck/config/link-check.json
@@ -61,6 +61,14 @@
       "comment": "Ignore specific HackQuest link",
       "pattern": "^http(s)?://www.hackquest.io/en/hackathon/Linea-Dev-Cook-Off"
     }
+   {
+      "comment": "Ignore specific HackQuest link",
+      "pattern": "^https?://www\\.hackquest\\.io/en/hackathon/Linea-Dev-Cook-Off"
+    },
+    {
+      "comment": "Ignore specific Android links",
+      "pattern": "^https?://developer\\.android\\.com/guide/components/(processes-and-threads#IPC|aidl)"
+    }
   ],
   "httpHeaders": [
     {


### PR DESCRIPTION
Added the following link so that the MetaMask docs link checker will pass:

- https://developer.android.com/training/dependency-injection/hilt-android (Status: 0, redirect loop)
- https://developer.android.com/guide/components/processes-and-threads#IPC (Status: 0, redirect loop)
- https://developer.android.com/guide/components/aidl (Status: 0, redirect loop)

 It seems as though their redirects are doing something funky