### PR TITLE
Add terms for DIN.

### DIFF
--- a/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
+++ b/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
@@ -61,6 +61,7 @@ Etherscan
 Etherspot
 Figma
 Filecoin
+Fireblocks
 Ganache
 [gG]asless
 Geth
@@ -179,6 +180,7 @@ Rinkeby
 Roboto
 Ropsten
 RPCs
+[Rr]unbook[s]?
 [sS]andbox(?:ing|ed)?
 [sS]ample[s]?
 Scamfari
@@ -193,6 +195,7 @@ Sentio
 [sS]essionToken
 Schnorr
 Slack
+SLA[s]?
 Socket.IO
 SphereX
 Splunk


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `Fireblocks`, `Runbook(s)`, and `SLA(s)` to the Consensys-common accepted spelling vocabulary.
> 
> - **Docs spelling vocabulary** (`docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt`):
>   - Add accepted terms: `Fireblocks`, `[Rr]unbook[s]?`, `SLA[s]?`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8885929f64062d72a21f39e849736423749d82c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->