### PR TITLE
Add additional config.

### DIFF
--- a/docs-link-check/config/.linkspector.yml
+++ b/docs-link-check/config/.linkspector.yml
@@ -1,3 +1,12 @@
+dirs:
+  - ./docs            # or "." if you want the whole repo
+excludedDirs:
+  - ./build
+  - ./.vercel
+  - ./.docusaurus
+  - ./node_modules
+useGitIgnore: true
+
 ignorePatterns:
 - pattern: "^http(s)?://localhost"
 - pattern: "^http(s)?://127.0.0.1"


### PR DESCRIPTION
According the instructions a file/dir must be specified:
https://github.com/UmbrellaDocs/linkspector?tab=readme-ov-file#default-configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configure Linkspector to scan `./docs`, exclude common build/output dirs, and respect `.gitignore`.
> 
> - **Config** (`docs-link-check/config/.linkspector.yml`):
>   - Set `dirs: ['./docs']`.
>   - Add `excludedDirs`: `./build`, `./.vercel`, `./.docusaurus`, `./node_modules`.
>   - Enable `useGitIgnore: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8fed310b314161c25bc1788963e30f2b24a104f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->