### PR TITLE
add filter mode to link check

### DIFF
--- a/docs-link-check/action.yml
+++ b/docs-link-check/action.yml
@@ -9,10 +9,13 @@ inputs:
     required: false
     default: .github-actions/docs-link-check/config/.linkspector.yml
   FAIL_LEVEL:
-    description: 'the level at which to fail the build'
+    description: 'exit code for reviewdog when errors are found with severity greater than or equal to this level'
     required: false
     default: 'any'
-
+  FILTER_MODE:
+    description: 'filtering mode for reviewdog command'
+    required: false
+    default: 'nofilter'
 runs:
   using: "composite"
   steps:
@@ -27,3 +30,4 @@ runs:
       with:
         config_file: ${{ inputs.CONFIG_FILE }}
         fail_level: ${{ inputs.FAIL_LEVEL }}
+        filter_mode: ${{ inputs.FILTER_MODE }}


### PR DESCRIPTION
Add [filter mode](https://github.com/UmbrellaDocs/action-linkspector?tab=readme-ov-file#filter_mode) to linkspector action to show errors across all files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `FILTER_MODE` input to the docs link check action and pass it to linkspector; refine `FAIL_LEVEL` description.
> 
> - **CI/GitHub Actions**:
>   - Update `docs-link-check/action.yml`:
>     - Add `FILTER_MODE` input (default `nofilter`) and pass `filter_mode` to `umbrelladocs/action-linkspector`.
>     - Clarify `FAIL_LEVEL` input description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ddf7fcba088d25d3e89f39894c28850f73273e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->