### PR TITLE
linkchecker via npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 https://github.com/Consensys/github-actions acts as a single source of truth (sot) for actions that we use
 
+# TODO
+- Add lint checks on this repo

--- a/docs-link-check/action.yml
+++ b/docs-link-check/action.yml
@@ -25,11 +25,40 @@ runs:
         repository: Consensys/github-actions
         path: .github-actions
 
-    # also needs reviewdog/action-setup@v1
-    # reviewdog/action-setup@d8edfce3dd5e1ec6978745e801f9c50b5ef80252
-    - name: Test links
-      uses: umbrelladocs/action-linkspector@652f85bc57bb1e7d4327260decc10aa68f7694c3
+    - name: Read .nvmrc
+      shell: bash
+      run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+      id: nvm
+
+    - name: Use Node.js 
+      uses: actions/setup-node@v6
       with:
-        config_file: ${{ inputs.CONFIG_FILE }}
-        fail_level: ${{ inputs.FAIL_LEVEL }}
-        filter_mode: ${{ inputs.FILTER_MODE }}
+        registry-url: https://registry.npmjs.org/
+        node-version-file: '.nvmrc'
+
+    # Fix Chrome sandbox issues on Ubuntu 24.04
+    - name: Setup Chrome Linux Sandbox
+      shell: bash    
+      run: |
+        # Based on https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+        if [ "$(lsb_release -rs)" = "24.04" ]; then
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          echo 'Done'
+        else
+          echo "Not running on Ubuntu 24.04 — skipping sandbox fix"
+        fi
+
+    - name: Install linkspector
+      shell: bash
+      run: |
+        npm install -g @umbrelladocs/linkspector
+        echo 'linkspector version: $(linkspector --version)'
+    
+    # Run linkspector and fail if there are broken links
+    - name: Run linkspector
+      shell: bash    
+      run: |
+        set -eo pipefail
+        echo "🔍 Checking for broken links..."
+        linkspector check -c ${{ inputs.CONFIG_FILE }}
+        


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the docs link check to run linkspector via npm with Node setup and adds a Chrome sandbox workaround for Ubuntu 24.04.
> 
> - **CI: `docs-link-check/action.yml`**
>   - Read Node version from `.nvmrc` and set up Node via `actions/setup-node@v6`.
>   - Add Ubuntu 24.04 Chrome sandbox workaround.
>   - Install and run `@umbrelladocs/linkspector` CLI (`linkspector check -c ${{ inputs.CONFIG_FILE }}`) instead of the action.
> - **Docs**
>   - Update `README.md` with a TODO to add lint checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1e2bba6197ad88296f66b63078ececbf7f328a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->