### PR TITLE
attempts to make vale lint only files touched by pr

### DIFF
--- a/docs-spelling-check/action.yml
+++ b/docs-spelling-check/action.yml
@@ -5,9 +5,9 @@ description: 'Composite action to test spelling'
 
 inputs:
   FILEPATHS:
-    description: 'Filepaths to look at, specified as a comma separated string ie "docs,blog,etc"'
+    description: 'Filepaths to look at, specified as a comma separated string with glob patterns ie "docs/**/*.md,blog/**/*.mdx,etc"'
     required: false
-    default: 'docs'  
+    default: 'docs/**/*.md,docs/**/*.mdx'  
 
 runs:
   using: "composite"
@@ -18,19 +18,24 @@ runs:
         repository: Consensys/github-actions
         path: .github-actions
 
+    # 2f7c5bfce28377bc069a65ba478de0a74aa0ca32 = v46.0.1 as at 18032025
+    - uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+      id: changed-files
+      with:
+        files: ${{ inputs.FILEPATHS }}
+        separator: ','
+        output_separator: '\n'
+
     - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
     # 38bf078c328061f59879b347ca344a718a736018 = v2 as at 24092024
     - name: Vale
+      if: ${{ steps.changed-files.outputs.all_changed_files != '' }}
       uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018
       with:
-        files: ${{ inputs.FILEPATHS }}
-        separator: ","
-        vale_flags: "--config .github-actions/docs-spelling-check/.vale.ini --glob={*.md,*.mdx}"
+        files: ${{ steps.changed-files.outputs.all_changed_files }}
+        vale_flags: "--config .github-actions/docs-spelling-check/.vale.ini"
         # fail_on_error: true
         reporter: github-pr-check
-
-
-     


### PR DESCRIPTION
This attempts to reduce size of vale output by restricting lint to files in pr:

LLM-assisted. Summary:

FILEPATHS is a comma-separated list of globs (with a sensible default).

tj-actions/changed-files:

Splits FILEPATHS on , (separator: ',').

Filters the changed PR files against those globs.

Joins the matching files with newlines via output_separator: '\n'.

The Vale step:

Only runs if all_changed_files is non-empty.

Receives a newline-separated list of changed files, which errata-ai/vale-action can consume just fine.

Uses your pinned config file and reports via github-pr-check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits Vale to PR-touched files via changed-files and updates FILEPATHS to comma-separated globs with sensible defaults.
> 
> - **GitHub Actions: `docs-spelling-check/action.yml`**
>   - Add `tj-actions/changed-files` (pinned) to compute changed files matching `FILEPATHS` (comma-separated globs) and output newline-separated list.
>   - Update `inputs.FILEPATHS` description and default to glob patterns (`docs/**/*.md, docs/**/*.mdx`).
>   - Make Vale step conditional on having changed files and pass computed file list; simplify flags by removing previous `separator` and `--glob` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc71720e6566403e0a7aa6b8a3e4286f66c2697d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->