### PR TITLE
attempted fix to lint only changed files

### DIFF
--- a/docs-lint-markdown/action.yml
+++ b/docs-lint-markdown/action.yml
@@ -16,6 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Also set `fetch-depth: 0` on the source repo so the action can compare the current head against the base branch.
     - name: Checkout tools repo
       uses: actions/checkout@v5
       with:
@@ -26,11 +27,12 @@ runs:
     - uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
       id: changed-files
       with:
-        files:  ${{ inputs.FILEPATHS }}
+        files: ${{ inputs.FILEPATHS }}
+        # output strings separator
         separator: ','
 
     - name: markdown lint
-      if: ${{ steps.changed-files.outputs.all_changed_files != '' }}
+      if: steps.changed-files.outputs.any_changed == 'true'
       uses: DavidAnson/markdownlint-cli2-action@v17
       with:
         config: ${{ inputs.CONFIG_FILE }}

--- a/docs-spelling-check/action.yml
+++ b/docs-spelling-check/action.yml
@@ -3,9 +3,19 @@
 name: 'test: spelling'
 description: 'Composite action to test spelling'
 
+inputs:
+  FILEPATHS:
+    description: 'Filepaths to look at, specified as a comma separated string ie "docs/**/*.md,blog/**/*.md,etc"'
+    required: false
+    default: |
+      **/*.md
+      **/*.mdx
+
+
 runs:
   using: "composite"
   steps:
+    # Also set `fetch-depth: 0` on the source repo so the action can compare the current head against the base branch.
     - name: Checkout tools repo
       uses: actions/checkout@v5
       with:
@@ -16,9 +26,8 @@ runs:
     - uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
       id: changed-files
       with:
-        files: |
-          **/*.md
-          **/*.mdx
+        files: ${{ inputs.FILEPATHS }}
+        # input files separator
         files_separator: "\n"
 
     - uses: actions/setup-python@v6
@@ -27,7 +36,7 @@ runs:
 
     # 38bf078c328061f59879b347ca344a718a736018 = v2 as at 24092024
     - name: Vale
-      if: ${{ steps.changed-files.outputs.all_changed_files != '' }}
+      if: steps.changed-files.outputs.any_changed == 'true'
       uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018
       with:
         files: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Last attempt to lint only changed files on pr was a fail, this is an attempted fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI gating and file selection logic for markdown and Vale checks; misconfiguration could cause checks to silently skip or lint the wrong files.
> 
> **Overview**
> Updates the `docs-lint-markdown` and `docs-spelling-check` composite actions to run only when `tj-actions/changed-files` reports relevant files changed (switching to `any_changed == 'true'`).
> 
> Adjusts changed-file input/output separators and expands the spelling check default globs to newline-separated `**/*.md` and `**/*.mdx`, improving compatibility with downstream actions that consume the changed file list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6594bf0f7e745ea4707854b346a5215b80e1259. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->