### PR TITLE
spell test only on changes and not every file

### DIFF
--- a/docs-spelling-check/action.yml
+++ b/docs-spelling-check/action.yml
@@ -26,10 +26,19 @@ runs:
     - uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
       id: changed-files
       with:
+        path: "."  # look in the main repo root
         files: ${{ inputs.FILEPATHS }}
-        # input files separator
-        files_separator: "\n"
+ 
+    - name: List Changed Files
+      if: steps.changed-files.outputs.any_changed == 'true'
+      shell: bash
+      run: |
+        echo "The following files were detected for spellcheck:"
+        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          echo "  - $file"
+        done
 
+    # need this for vale
     - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
@@ -40,7 +49,6 @@ runs:
       uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018
       with:
         files: ${{ steps.changed-files.outputs.all_changed_files }}
-        separator: "\n"
         vale_flags: "--config .github-actions/docs-spelling-check/.vale.ini"
         # fail_on_error: true
         reporter: github-pr-check


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow tweak that changes which docs files are linted and adds logging; low impact beyond potentially missing/adding checks depending on change-file detection.
> 
> **Overview**
> Updates the `docs-spelling-check` composite action to **scope Vale spellchecking to files changed in the PR** (via `tj-actions/changed-files`), instead of scanning all matched files.
> 
> Adds an explicit repo-root `path` for change detection and a debug step that logs the files selected for spellcheck, while cleaning up the prior newline separator configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7cdd2afc6a74032d5db1e3bb06e62c3b0cbfe45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->