### PR TITLE
updates spelling rules 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 .idea
+
+docs-spelling-check/styles/Microsoft/
+docs-spelling-check/styles/proselint/
+docs-spelling-check/styles/write-good/

--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 
 https://github.com/Consensys/github-actions acts as a single source of truth (sot) for actions that we use
 
-# TODO
-- Add lint checks on this repo

--- a/docs-spelling-check/styles/Consensys/Headings.yml
+++ b/docs-spelling-check/styles/Consensys/Headings.yml
@@ -34,6 +34,7 @@ exceptions:
   - ECMAScript
   - EIP
   - Electron
+  - Embedded Wallets
   - Emmet
   - EOA
   - ERC

--- a/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
+++ b/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
@@ -94,6 +94,7 @@ InfluxDB
 Infura
 [iI]nterlockUrl
 IntraLayer
+[iI]nviter(?:'s)?
 Irys
 Jasypt
 JMeter
@@ -161,6 +162,7 @@ Pegasys
 [pP]repend(?:s|ing|ed)?
 [Pp]recompile[s]?
 Photoshop
+[pP]imlico(?:'s)?
 Polkadot
 Postgres
 Powershell
@@ -242,6 +244,7 @@ USB Armory Mk II
 Vercel
 Vertx
 vCPU[s]?
+[vV]iem(?:'s)?
 [vV]ue
 [wW]agmi
 [wW]eb3


### PR DESCRIPTION
and ignores files (reducing impact of cursor overreach)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts ignore patterns and spelling/style configuration; no runtime or security-sensitive logic changes.
> 
> **Overview**
> Updates the docs spelling configuration by adding new accepted terms (`inviter`, `pimlico`, `viem`) and allowing `Embedded Wallets` as a heading exception.
> 
> Extends `.gitignore` to ignore IDE metadata and the vendored `docs-spelling-check` style directories (`Microsoft`, `proselint`, `write-good`), and removes the stale TODO block from `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35d4dd0aa49b4e35938b11890cd985d3b012faeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->