### PR TITLE
feat: add Zesu to accepted spelling vocabulary

### DIFF
--- a/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
+++ b/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
@@ -295,6 +295,7 @@ Web3Signer
 X-Chain
 Yield Boost
 [yY]aml|YAML
+Zesu
 Zinken
 ZKsync Era
 zkEVM


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation spell-check config only; no runtime or security impact.
> 
> **Overview**
> Adds **Zesu** to the Consensys-common spelling vocabulary (`accept.txt`) so the docs spell checker stops flagging it as a typo.
> 
> This is a one-line vocabulary update alongside existing product/chain names (e.g. Zinken, ZKsync Era).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb4f143c3b02ef02ccfbeafc5dc930f46ba6d6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->