### PR TITLE
feat(vale): add Linea/Lineth terms to Consensys-common vocabulary

### DIFF
--- a/docs-spelling-check/styles/config/ignore/Consensys-common/project-words.txt
+++ b/docs-spelling-check/styles/config/ignore/Consensys-common/project-words.txt
@@ -286,6 +286,8 @@ déja
 delegators
 delisted
 dencun
+deployer
+deployer's
 deps
 deri
 deso
@@ -689,6 +691,7 @@ ldo
 leaderboard
 leaderboards
 lenster
+lfdt
 libdebug
 libp
 librocksdbjni
@@ -705,6 +708,8 @@ lineabuild
 lineascan
 lineaster
 linea's
+lineth
+lineth's
 linenums
 linkify
 listschains
@@ -732,6 +737,8 @@ mapbox
 marcey
 markdownextradata
 marocchino
+maru
+maru's
 massoud
 matchers
 mathbb
@@ -1036,6 +1043,7 @@ quelquejay
 queryid
 querystring
 quickstart
+quickstart's
 quickwit
 quorum
 quorumengineering

--- a/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
+++ b/docs-spelling-check/styles/config/vocabularies/Consensys-common/accept.txt
@@ -133,15 +133,18 @@ libsodium
 Lineaplorer
 Linea Voyage
 Linea Yield Boost
+[Ll]ineth(?:'s)?
 Linkspector
 Logback
 Logrus
 Logstash
+LFDT
 LPs
 LSTs?
 [mM]ainnet[s]?
 Markdown
 Markdownlint
+Maru(?:'s)?
 [mM]arshal(?:ing|ed)?
 Medalla
 [Mm]empool


### PR DESCRIPTION
## Summary

Adds missing Linea/Lineth-specific terms to the shared `Consensys-common` Vale vocabulary so they no longer trigger `Consensys.Spelling` warnings on every `Consensys/doc.linea` PR.

**Terms added to `accept.txt`:**
- `[Ll]ineth(?:'s)?` — Lineth stack/protocol name (replaces "Linea Stack"; appears in 45+ doc files)
- `Maru(?:'s)?` — Lineth consensus layer client
- `LFDT` — Linux Foundation Decentralized Trust

**Terms added to `project-words.txt`:**
- `lineth`, `lineth's`
- `maru`, `maru's`
- `deployer`, `deployer's` — used throughout Stack quickstart docs (~24 hits per PR)
- `quickstart's` — possessive form (`quickstart` was already in the ignore list)
- `lfdt`

## Context

These terms show up as `Consensys.Spelling` warnings on every doc.linea PR that touches Stack content. They are valid product names and technical terms for the Lineth zk-rollup stack documented on docs.linea.build. The dictionary fix needs to live here since the action is referenced by commit hash from the doc.linea CI workflow.

Following pattern from existing entries (e.g., `Teku`, `Web3Signer`, `[vV]alidium[s]?(?:'s)?`).

Discussed with Joshua Fernandes on Slack — correct process is to PR here and ping for review.

cc @joshuafernandes @byrongravenorst @alexandracarillo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-tooling dictionary updates only; no application code, auth, or data paths affected.
> 
> **Overview**
> Extends the shared **Consensys-common** Vale spelling config so Linea/Lineth documentation stops raising false **`Consensys.Spelling`** hits in downstream repos (e.g. `doc.linea`).
> 
> **`accept.txt`** gains regex accept rules for **`Lineth`** (with possessive), **`Maru`**, and **`LFDT`**. **`project-words.txt`** adds the same product terms plus **`deployer`**, **`deployer's`**, **`quickstart's`**, and **`lfdt`** for the ignore list used by the spelling style.
> 
> No runtime or CI logic changes—only dictionary/vocabulary updates, following existing patterns like **`Teku`** and **`Web3Signer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf903b517d7566776ab8ac3c3228ea4697e32d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->